### PR TITLE
Fix typo – a missing verb

### DIFF
--- a/babel.dtx
+++ b/babel.dtx
@@ -455,7 +455,7 @@ layout (eg, |spanish| and |french|).
 \end{example}
 
 You can also set the main language explicitly, but it is discouraged
-except if there a real reason to do so:
+except if there is a real reason to do so:
 \begin{verbatim}
 \documentclass{article}
 \usepackage[_main=english_,dutch]{babel}


### PR DESCRIPTION
This PR fixes a small typo – a missing verb in the sentence in the documentation.